### PR TITLE
Made ppm[] array in rc_900_rx.ino volatile

### DIFF
--- a/rc_900_rx/rc_900_rx.ino
+++ b/rc_900_rx/rc_900_rx.ino
@@ -33,7 +33,7 @@ RH_RF95 rf95(RFM95_CS, RFM95_INT);
 
 /*this array holds the servo values for the ppm signal
  change theese values in your code (usually servo values move between 1000 and 2000)*/
-uint16_t ppm[NUM_CHANNELS];
+volatile uint16_t ppm[NUM_CHANNELS];
 //////////////////////////////////////////////////////////////////
 
 #define PACKET_TIMEOUT 300


### PR DESCRIPTION
This is not tested, but should work.